### PR TITLE
overhaul: switching to watch channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["asynchronous", "concurrency", "caching"]
 
 [dependencies]
 hashbrown = "0.12"
-tokio = {version = "1.19", features = ["sync"]}
 parking_lot = "0.12"
+tokio = {version = "1.19", features = ["sync"]}
 
 [dev-dependencies]
-tokio = {version = "1", features = ["full"]}
 futures = "0.3"
+tokio = {version = "1", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["asynchronous", "concurrency", "caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hashbrown = "0.11"
+hashbrown = "0.12"
 tokio = {version = "1", features = ["sync"]}
-parking_lot = "0.11"
+parking_lot = "0.12"
 
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "concurrency", "caching"]
 
 [dependencies]
 hashbrown = "0.12"
-tokio = {version = "1", features = ["sync"]}
+tokio = {version = "1.19", features = ["sync"]}
 parking_lot = "0.12"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! ```
 //!
 
+use std::fmt::{self, Debug};
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -47,13 +48,30 @@ use tokio::sync::watch;
 
 /// Group represents a class of work and creates a space in which units of work
 /// can be executed with duplicate suppression.
-#[derive(Default)]
 pub struct Group<T, E>
 where
     T: Clone,
 {
     m: Mutex<HashMap<String, watch::Receiver<State<T>>>>,
     _marker: PhantomData<fn(E)>,
+}
+
+impl<T, E> Debug for Group<T, E>
+where
+    T: Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Group").finish()
+    }
+}
+
+impl<T, E> Default for Group<T, E>
+where
+    T: Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
There is no way to retry when leader future has been dropped. Switching to `Watch` channel to fix it.

It's my first time to implement `Future` directly, and I'm apprecated if any suggestions.