### PR TITLE
refactor: async_singleflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "async_singleflight"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "dashmap",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "async_singleflight"
 version = "0.5.3"
 dependencies = [
+ "dashmap",
  "futures",
- "hashbrown",
- "parking_lot",
  "pin-project",
  "tokio",
 ]
@@ -74,16 +67,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
+name = "crossbeam-utils"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "dashmap"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "futures"
@@ -182,14 +183,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "io-uring"
@@ -252,6 +248,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "dashmap",
  "futures",
  "pin-project",
+ "thiserror",
  "tokio",
 ]
 
@@ -389,6 +390,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,10 @@ categories = ["asynchronous", "concurrency", "caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hashbrown = "0.15"
-parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["sync"] }
 futures = "0.3"
+dashmap = "6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_singleflight"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Pure White <wudi@purewhite.io>"]
 edition = "2021"
 description = "Async singleflight."
@@ -12,10 +12,10 @@ categories = ["asynchronous", "concurrency", "caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pin-project = "1"
-tokio = { version = "1", features = ["sync"] }
-futures = "0.3"
 dashmap = "6"
+pin-project = "1"
+tokio = { version = "1", features = [ "sync" ] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+tokio = { version = "1", features = [ "full" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["asynchronous", "concurrency", "caching"]
 
 [dependencies]
 dashmap = "6"
+thiserror = "2"
 pin-project = "1"
 tokio = { version = "1", features = [ "sync" ] }
 

--- a/src/group.rs
+++ b/src/group.rs
@@ -46,10 +46,12 @@ where
     }
 
     /// Execute and return the value for a given function, making sure that only one
-    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
-    /// wait until the original call completes and return the same value.
-    /// Only owner call returns error if exists.
-    /// The third return value indicates whether the call is the owner.
+    /// operation is in-flight at a given moment.
+    ///
+    /// - If a duplicate call comes in, that caller will wait until the original
+    ///   call completes and return the same value.
+    ///
+    /// - Only owner call returns error if exists.
     pub async fn work<Q, F>(&self, key: &Q, fut: F) -> Result<T, Option<E>>
     where
         Q: Hash + Eq + ?Sized + ToOwned<Owned = K>,

--- a/src/group.rs
+++ b/src/group.rs
@@ -31,6 +31,49 @@ where
     }
 }
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum GroupWorkError<E> {
+    #[error("Leader returned an error")]
+    LeaderFailed,
+    #[error("Leader has been dropped")]
+    LeaderDropped,
+    #[error("Error returned by the leader")]
+    Error(E),
+}
+
+impl<E> GroupWorkError<E> {
+    pub fn unwrap_err(self) -> E {
+        match self {
+            GroupWorkError::Error(err) => err,
+            _ => panic!("called `unwrap_err` on a non-error variant"),
+        }
+    }
+
+    pub fn as_ref(&self) -> GroupWorkError<&E> {
+        match self {
+            GroupWorkError::Error(err) => GroupWorkError::Error(err),
+            GroupWorkError::LeaderFailed => GroupWorkError::LeaderFailed,
+            GroupWorkError::LeaderDropped => GroupWorkError::LeaderDropped,
+        }
+    }
+
+    pub fn into_inner(self) -> E {
+        match self {
+            GroupWorkError::Error(err) => err,
+            _ => panic!("called `into_inner` on a non-error variant"),
+        }
+    }
+}
+
+impl<E> From<GroupWorkError<E>> for Option<E> {
+    fn from(err: GroupWorkError<E>) -> Self {
+        match err {
+            GroupWorkError::Error(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl<T, E, K> Group<T, E, K>
 where
     T: Clone,
@@ -45,75 +88,108 @@ where
         }
     }
 
+    async fn work_inner<Q, F>(&self, key: &Q, fut: &mut Option<F>) -> Result<T, GroupWorkError<E>>
+    where
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        F: Future<Output = Result<T, E>> + Send,
+        K: std::borrow::Borrow<Q>,
+    {
+        let handler = if let Some(state_ref) = self.map.get(key) {
+            let state = state_ref.borrow().clone();
+            match state {
+                State::Starting => ChannelHandler::Receiver(state_ref.clone()),
+                State::LeaderDropped => {
+                    drop(state_ref);
+                    // switch into leader if leader dropped
+                    let (tx, rx) = watch::channel(State::Starting);
+                    self.map.insert(key.to_owned(), rx);
+                    ChannelHandler::Sender(tx)
+                }
+                State::Success(val) => return Ok(val),
+                State::LeaderFailed => return Err(GroupWorkError::LeaderFailed),
+            }
+        } else {
+            let (tx, rx) = watch::channel(State::Starting);
+            self.map.insert(key.to_owned(), rx);
+            ChannelHandler::Sender(tx)
+        };
+
+        match handler {
+            ChannelHandler::Sender(tx) => {
+                let leader = Leader::new(
+                    fut.take()
+                        .expect("future should be available when becoming leader"),
+                    tx,
+                );
+                let result = leader.await;
+                let _ = self.map.remove(key);
+                match result {
+                    Ok(val) => Ok(val),
+                    Err(err) => Err(GroupWorkError::Error(err)),
+                }
+            }
+            ChannelHandler::Receiver(mut rx) => {
+                let mut state = rx.borrow_and_update().clone();
+                if matches!(state, State::Starting) {
+                    let _changed = rx.changed().await;
+                    state = rx.borrow().clone();
+                }
+                match state {
+                    State::Starting => unreachable!(), // unreachable
+                    State::LeaderDropped => {
+                        let _ = self.map.remove(key);
+                        // the leader dropped
+                        Err(GroupWorkError::LeaderDropped)
+                    }
+                    State::Success(val) => Ok(val),
+                    State::LeaderFailed => Err(GroupWorkError::LeaderFailed),
+                }
+            }
+        }
+    }
+
     /// Execute and return the value for a given function, making sure that only one
     /// operation is in-flight at a given moment.
     ///
     /// - If a duplicate call comes in, that caller will wait until the original
     ///   call completes and return the same value.
-    ///
     /// - Only owner call returns error if exists.
     pub async fn work<Q, F>(&self, key: &Q, fut: F) -> Result<T, Option<E>>
     where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K>,
-        F: Future<Output = Result<T, E>>,
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        F: Future<Output = Result<T, E>> + Send,
         K: std::borrow::Borrow<Q>,
     {
-        // Use a loop to avoid async tail recursion on leader dropped
         let mut fut_opt = Some(fut);
-        loop {
-            let handler = if let Some(state_ref) = self.map.get(key) {
-                let state = state_ref.borrow().clone();
-                match state {
-                    State::Starting => ChannelHandler::Receiver(state_ref.clone()),
-                    State::LeaderDropped => {
-                        drop(state_ref);
-                        // switch into leader if leader dropped
-                        let (tx, rx) = watch::channel(State::Starting);
-                        self.map.insert(key.to_owned(), rx);
-                        ChannelHandler::Sender(tx)
-                    }
-                    State::Success(val) => return Ok(val),
-                    State::LeaderFailed => return Err(None),
-                }
-            } else {
-                let (tx, rx) = watch::channel(State::Starting);
-                self.map.insert(key.to_owned(), rx);
-                ChannelHandler::Sender(tx)
-            };
 
-            match handler {
-                ChannelHandler::Sender(tx) => {
-                    let fut = Leader::new(
-                        fut_opt
-                            .take()
-                            .expect("future should be available when becoming leader"),
-                        tx,
-                    );
-                    let result = fut.await;
-                    let _ = self.map.remove(key);
-                    match result {
-                        Ok(val) => return Ok(val),
-                        Err(err) => return Err(Some(err)),
-                    }
+        // Use a loop to avoid async tail recursion on leader dropped
+        loop {
+            match self.work_inner(key, &mut fut_opt).await {
+                Err(GroupWorkError::LeaderDropped) => {
+                    // Retry the loop, potentially becoming leader, and consuming the future
+                    continue;
                 }
-                ChannelHandler::Receiver(mut rx) => {
-                    let mut state = rx.borrow_and_update().clone();
-                    if matches!(state, State::Starting) {
-                        let _changed = rx.changed().await;
-                        state = rx.borrow().clone();
-                    }
-                    match state {
-                        State::Starting => unreachable!(), // unreachable
-                        State::LeaderDropped => {
-                            let _ = self.map.remove(key);
-                            // the leader dropped, so we retry the loop, potentially becoming leader
-                            continue;
-                        }
-                        State::Success(val) => return Ok(val),
-                        State::LeaderFailed => return Err(None),
-                    }
-                }
+                Ok(val) => return Ok(val),
+                Err(GroupWorkError::Error(err)) => return Err(Some(err)),
+                Err(GroupWorkError::LeaderFailed) => return Err(None),
             }
         }
+    }
+
+    /// Execute and return the value for a given function, making sure that only one
+    /// operation is in-flight at a given moment.
+    ///
+    /// - If a duplicate call comes in, that caller will wait until the original
+    ///   call completes and return the same value.
+    /// - Only owner call returns error if exists.
+    /// - If the leader drops, the call will return `None`.
+    pub async fn work_no_retry<Q, F>(&self, key: &Q, fut: F) -> Result<T, GroupWorkError<E>>
+    where
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        F: Future<Output = Result<T, E>> + Send,
+        K: std::borrow::Borrow<Q>,
+    {
+        let mut fut_opt = Some(fut);
+        self.work_inner(key, &mut fut_opt).await
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+/// Group represents a class of work and creates a space in which units of work
+/// can be executed with duplicate suppression.
+pub struct Group<T, E, K = String>
+where
+    T: Clone,
+    K: Hash + Eq,
+{
+    map: DashMap<K, watch::Receiver<State<T>>>,
+    _marker: PhantomData<fn(E)>,
+}
+
+impl<T, E, K> Debug for Group<T, E, K>
+where
+    T: Clone,
+    K: Hash + Eq,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Group").finish()
+    }
+}
+
+impl<T, E, K> Default for Group<T, E, K>
+where
+    T: Clone,
+    K: Hash + Eq,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, E, K> Group<T, E, K>
+where
+    T: Clone,
+    K: Hash + Eq,
+{
+    /// Create a new Group to do work with.
+    #[must_use]
+    pub fn new() -> Group<T, E, K> {
+        Self {
+            map: DashMap::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Execute and return the value for a given function, making sure that only one
+    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
+    /// wait until the original call completes and return the same value.
+    /// Only owner call returns error if exists.
+    /// The third return value indicates whether the call is the owner.
+    pub async fn work<Q, F>(&self, key: &Q, fut: F) -> Result<T, Option<E>>
+    where
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K>,
+        F: Future<Output = Result<T, E>>,
+        K: std::borrow::Borrow<Q>,
+    {
+        // Use a loop to avoid async tail recursion on leader dropped
+        let mut fut_opt = Some(fut);
+        loop {
+            let handler = if let Some(state_ref) = self.map.get(key) {
+                let state = state_ref.borrow().clone();
+                match state {
+                    State::Starting => ChannelHandler::Receiver(state_ref.clone()),
+                    State::LeaderDropped => {
+                        drop(state_ref);
+                        // switch into leader if leader dropped
+                        let (tx, rx) = watch::channel(State::Starting);
+                        self.map.insert(key.to_owned(), rx);
+                        ChannelHandler::Sender(tx)
+                    }
+                    State::Success(val) => return Ok(val),
+                    State::LeaderFailed => return Err(None),
+                }
+            } else {
+                let (tx, rx) = watch::channel(State::Starting);
+                self.map.insert(key.to_owned(), rx);
+                ChannelHandler::Sender(tx)
+            };
+
+            match handler {
+                ChannelHandler::Sender(tx) => {
+                    let fut = Leader::new(
+                        fut_opt
+                            .take()
+                            .expect("future should be available when becoming leader"),
+                        tx,
+                    );
+                    let result = fut.await;
+                    let _ = self.map.remove(key);
+                    match result {
+                        Ok(val) => return Ok(val),
+                        Err(err) => return Err(Some(err)),
+                    }
+                }
+                ChannelHandler::Receiver(mut rx) => {
+                    let mut state = rx.borrow_and_update().clone();
+                    if matches!(state, State::Starting) {
+                        let _changed = rx.changed().await;
+                        state = rx.borrow().clone();
+                    }
+                    match state {
+                        State::Starting => unreachable!(), // unreachable
+                        State::LeaderDropped => {
+                            let _ = self.map.remove(key);
+                            // the leader dropped, so we retry the loop, potentially becoming leader
+                            continue;
+                        }
+                        State::Success(val) => return Ok(val),
+                        State::LeaderFailed => return Err(None),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     for _ in 0..10 {
 //!         let g = g.clone();
 //!         handlers.push(tokio::spawn(async move {
-//!             let res = g.work("key", expensive_fn()).await.0;
+//!             let res = g.work("key", expensive_fn()).await;
 //!             let r = res.unwrap();
 //!             println!("{}", r);
 //!         }));
@@ -42,152 +42,53 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+mod group;
+mod unary;
+
+pub use group::*;
+pub use unary::*;
+
 use dashmap::DashMap;
-use futures::future::BoxFuture;
 use pin_project::{pin_project, pinned_drop};
 use std::hash::Hash;
 use tokio::sync::watch;
-
-/// Group represents a class of work and creates a space in which units of work
-/// can be executed with duplicate suppression.
-pub struct Group<T, E, K = String>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
-    map: DashMap<K, watch::Receiver<State<T>>>,
-    _marker: PhantomData<fn(E)>,
-}
-
-impl<T, E, K> Debug for Group<T, E, K>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Group").finish()
-    }
-}
-
-impl<T, E, K> Default for Group<T, E, K>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Clone)]
 enum State<T: Clone> {
     Starting,
     LeaderDropped,
-    Done(Option<T>),
+    LeaderFailed,
+    Success(T),
 }
 
-impl<T, E, K> Group<T, E, K>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
-    /// Create a new Group to do work with.
-    #[must_use]
-    pub fn new() -> Group<T, E, K> {
-        Self {
-            map: DashMap::new(),
-            _marker: PhantomData,
-        }
-    }
-
-    /// Execute and return the value for a given function, making sure that only one
-    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
-    /// wait until the original call completes and return the same value.
-    /// Only owner call returns error if exists.
-    /// The third return value indicates whether the call is the owner.
-    pub async fn work<Q>(
-        &self,
-        key: &Q,
-        fut: impl Future<Output = Result<T, E>>,
-    ) -> (Option<T>, Option<E>, bool)
-    where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K>,
-        K: std::borrow::Borrow<Q>,
-    {
-        let tx_or_rx = if let Some(state_ref) = self.map.get(key) {
-            let state = state_ref.borrow().clone();
-            match state {
-                State::Starting => Err(state_ref.clone()),
-                State::LeaderDropped => {
-                    drop(state_ref);
-                    // switch into leader if leader dropped
-                    let (tx, rx) = watch::channel(State::Starting);
-                    self.map.insert(key.to_owned(), rx);
-                    Ok(tx)
-                }
-                State::Done(val) => return (val, None, false),
-            }
-        } else {
-            let (tx, rx) = watch::channel(State::Starting);
-            self.map.insert(key.to_owned(), rx);
-            Ok(tx)
-        };
-
-        match tx_or_rx {
-            Ok(tx) => {
-                let fut = Leader { fut, tx };
-                let result = fut.await;
-                self.map.remove(key);
-                match result {
-                    Ok(val) => (Some(val), None, true),
-                    Err(err) => (None, Some(err), true),
-                }
-            }
-            Err(mut rx) => {
-                let mut state = rx.borrow_and_update().clone();
-                if matches!(state, State::Starting) {
-                    let _changed = rx.changed().await;
-                    state = rx.borrow().clone();
-                }
-                match state {
-                    State::Starting => (None, None, false), // unreachable
-                    State::LeaderDropped => {
-                        self.map.remove(key);
-                        (None, None, false)
-                    }
-                    State::Done(val) => (val, None, false),
-                }
-            }
-        }
-    }
+enum ChannelHandler<T: Clone> {
+    Sender(watch::Sender<State<T>>),
+    Receiver(watch::Receiver<State<T>>),
 }
 
 #[pin_project(PinnedDrop)]
-struct Leader<T: Clone, F> {
+struct Leader<T: Clone, F, Output> {
     #[pin]
     fut: F,
     tx: watch::Sender<State<T>>,
+    _marker: PhantomData<Output>,
 }
 
-impl<T, E, F> Future for Leader<T, F>
+impl<T, F, Output> Leader<T, F, Output>
 where
     T: Clone,
-    F: Future<Output = Result<T, E>>,
 {
-    type Output = Result<T, E>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let result = this.fut.poll(cx);
-        if let Poll::Ready(val) = &result {
-            let _send = this.tx.send(State::Done(val.as_ref().ok().cloned()));
+    fn new(fut: F, tx: watch::Sender<State<T>>) -> Self {
+        Self {
+            fut,
+            tx,
+            _marker: PhantomData,
         }
-        result
     }
 }
 
 #[pinned_drop]
-impl<T, F> PinnedDrop for Leader<T, F>
+impl<T, F, Output> PinnedDrop for Leader<T, F, Output>
 where
     T: Clone,
 {
@@ -204,124 +105,27 @@ where
     }
 }
 
-/// UnaryGroup represents a class of work and creates a space in which units of work
-/// can be executed with duplicate suppression.
-pub struct UnaryGroup<T, K = String>
+impl<T, E, F> Future for Leader<T, F, Result<T, E>>
 where
     T: Clone,
-    K: Hash + Eq,
+    F: Future<Output = Result<T, E>>,
 {
-    map: DashMap<K, watch::Receiver<UnaryState<T>>>,
-}
+    type Output = Result<T, E>;
 
-impl<T> Debug for UnaryGroup<T>
-where
-    T: Clone,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UnaryGroup").finish()
-    }
-}
-
-impl<T> Default for UnaryGroup<T>
-where
-    T: Clone + Send + Sync,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Clone)]
-enum UnaryState<T: Clone> {
-    Starting,
-    LeaderDropped,
-    Done(T),
-}
-
-impl<T, K> UnaryGroup<T, K>
-where
-    T: Clone + Send + Sync,
-    K: Hash + Eq + Send + Sync,
-{
-    /// Create a new Group to do work with.
-    #[must_use]
-    pub fn new() -> UnaryGroup<T, K> {
-        Self {
-            map: DashMap::new(),
-        }
-    }
-
-    /// Execute and return the value for a given function, making sure that only one
-    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
-    /// wait until the original call completes and return the same value.
-    ///
-    /// The third return value indicates whether the call is the owner.
-    pub fn work<'s, Q>(
-        &'s self,
-        key: &'s Q,
-        fut: impl Future<Output = T> + Send + 's,
-    ) -> BoxFuture<'s, (T, bool)>
-    where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
-        K: std::borrow::Borrow<Q>,
-    {
-        Box::pin(async move {
-            let tx_or_rx = if let Some(state_ref) = self.map.get(key) {
-                let state = state_ref.borrow().clone();
-                match state {
-                    UnaryState::Starting => Err(state_ref.clone()),
-                    UnaryState::LeaderDropped => {
-                        drop(state_ref);
-                        // switch into leader if leader dropped
-                        let (tx, rx) = watch::channel(UnaryState::Starting);
-                        self.map.insert(key.to_owned(), rx);
-                        Ok(tx)
-                    }
-                    UnaryState::Done(val) => return (val, false),
-                }
-            } else {
-                let (tx, rx) = watch::channel(UnaryState::Starting);
-                self.map.insert(key.to_owned(), rx);
-                Ok(tx)
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = this.fut.poll(cx);
+        if let Poll::Ready(val) = &result {
+            let _send = match val {
+                Ok(v) => this.tx.send(State::Success(v.clone())),
+                Err(_) => this.tx.send(State::LeaderFailed),
             };
-
-            match tx_or_rx {
-                Ok(tx) => {
-                    let fut = UnaryLeader { fut, tx };
-                    let result = fut.await;
-                    self.map.remove(key);
-                    (result, true)
-                }
-                Err(mut rx) => {
-                    let mut state = rx.borrow_and_update().clone();
-                    if matches!(state, UnaryState::Starting) {
-                        let _changed = rx.changed().await;
-                        state = rx.borrow().clone();
-                    }
-                    match state {
-                        UnaryState::Starting => unreachable!(), // unreachable
-                        UnaryState::LeaderDropped => {
-                            self.map.remove(key);
-                            // the leader dropped, so we need to retry
-                            self.work(key, fut).await
-                        }
-                        UnaryState::Done(val) => (val, false),
-                    }
-                }
-            }
-        })
+        }
+        result
     }
 }
 
-#[pin_project(PinnedDrop)]
-struct UnaryLeader<T: Clone, F> {
-    #[pin]
-    fut: F,
-    tx: watch::Sender<UnaryState<T>>,
-}
-
-impl<T, F> Future for UnaryLeader<T, F>
+impl<T, F> Future for Leader<T, F, T>
 where
     T: Clone + Send + Sync,
     F: Future<Output = T>,
@@ -332,53 +136,37 @@ where
         let this = self.project();
         let result = this.fut.poll(cx);
         if let Poll::Ready(val) = &result {
-            let _send = this.tx.send(UnaryState::Done(val.clone()));
+            let _send = this.tx.send(State::Success(val.clone()));
         }
         result
     }
 }
 
-#[pinned_drop]
-impl<T, F> PinnedDrop for UnaryLeader<T, F>
-where
-    T: Clone,
-{
-    fn drop(self: Pin<&mut Self>) {
-        let this = self.project();
-        let _ = this.tx.send_if_modified(|s| {
-            if matches!(s, UnaryState::Starting) {
-                *s = UnaryState::LeaderDropped;
-                true
-            } else {
-                false
-            }
-        });
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::time::Duration;
-
-    use super::Group;
-
-    const RES: usize = 7;
 
     async fn return_res() -> Result<usize, ()> {
         Ok(7)
     }
 
-    async fn expensive_fn() -> Result<usize, ()> {
+    async fn expensive_fn<const RES: usize>() -> Result<usize, ()> {
         tokio::time::sleep(Duration::from_millis(500)).await;
         Ok(RES)
+    }
+
+    async fn expensive_unary_fn<const RES: usize>() -> usize {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        RES
     }
 
     #[tokio::test]
     async fn test_simple() {
         let g = Group::new();
-        let res = g.work("key", return_res()).await.0;
+        let res = g.work("key", return_res()).await;
         let r = res.unwrap();
-        assert_eq!(r, RES);
+        assert_eq!(r, 7);
     }
 
     #[tokio::test]
@@ -388,11 +176,11 @@ mod tests {
         use futures::future::join_all;
 
         let g = Arc::new(Group::new());
-        let mut handlers = Vec::new();
+        let mut handlers = Vec::with_capacity(10);
         for _ in 0..10 {
             let g = g.clone();
             handlers.push(tokio::spawn(async move {
-                let res = g.work("key", expensive_fn()).await.0;
+                let res = g.work("key", expensive_fn::<7>()).await;
                 let r = res.unwrap();
                 println!("{}", r);
             }));
@@ -408,13 +196,32 @@ mod tests {
         use futures::future::join_all;
 
         let g = Arc::new(Group::<_, _, u64>::new());
-        let mut handlers = Vec::new();
+        let mut handlers = Vec::with_capacity(10);
         for _ in 0..10 {
             let g = g.clone();
             handlers.push(tokio::spawn(async move {
-                let res = g.work(&42, expensive_fn()).await.0;
+                let res = g.work(&42, expensive_fn::<8>()).await;
                 let r = res.unwrap();
                 println!("{}", r);
+            }));
+        }
+
+        join_all(handlers).await;
+    }
+
+    #[tokio::test]
+    async fn test_multiple_threads_unary() {
+        use std::sync::Arc;
+
+        use futures::future::join_all;
+
+        let g = Arc::new(UnaryGroup::<_, u64>::new());
+        let mut handlers = Vec::with_capacity(10);
+        for _ in 0..10 {
+            let g = g.clone();
+            handlers.push(tokio::spawn(async move {
+                let res = g.work(&42, expensive_unary_fn::<8>()).await;
+                assert_eq!(res, 8);
             }));
         }
 
@@ -427,13 +234,16 @@ mod tests {
 
         let g = Group::new();
         {
-            tokio::time::timeout(Duration::from_millis(50), g.work("key", expensive_fn()))
-                .await
-                .expect_err("owner should be running and cancelled");
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                g.work("key", expensive_fn::<2>()),
+            )
+            .await
+            .expect_err("owner should be running and cancelled");
         }
         assert_eq!(
-            tokio::time::timeout(Duration::from_secs(1), g.work("key", expensive_fn())).await,
-            Ok((Some(RES), None, true)),
+            tokio::time::timeout(Duration::from_secs(1), g.work("key", expensive_fn::<7>())).await,
+            Ok(Ok(7))
         );
     }
 }

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -42,10 +42,10 @@ where
     }
 
     /// Execute and return the value for a given function, making sure that only one
-    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
-    /// wait until the original call completes and return the same value.
+    /// operation is in-flight at a given moment.
     ///
-    /// The third return value indicates whether the call is the owner.
+    /// - If a duplicate call comes in, that caller will wait until the original
+    ///   call completes and return the same value.
     pub async fn work<Q, F>(&self, key: &Q, fut: F) -> T
     where
         Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+/// UnaryGroup represents a class of work and creates a space in which units of work
+/// can be executed with duplicate suppression.
+pub struct UnaryGroup<T, K = String>
+where
+    T: Clone,
+    K: Hash + Eq,
+{
+    map: DashMap<K, watch::Receiver<State<T>>>,
+}
+
+impl<T> Debug for UnaryGroup<T>
+where
+    T: Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnaryGroup").finish()
+    }
+}
+
+impl<T> Default for UnaryGroup<T>
+where
+    T: Clone + Send + Sync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, K> UnaryGroup<T, K>
+where
+    T: Clone + Send + Sync,
+    K: Hash + Eq + Send + Sync,
+{
+    /// Create a new Group to do work with.
+    #[must_use]
+    pub fn new() -> UnaryGroup<T, K> {
+        Self {
+            map: DashMap::new(),
+        }
+    }
+
+    /// Execute and return the value for a given function, making sure that only one
+    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
+    /// wait until the original call completes and return the same value.
+    ///
+    /// The third return value indicates whether the call is the owner.
+    pub async fn work<Q, F>(&self, key: &Q, fut: F) -> T
+    where
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        F: Future<Output = T> + Send,
+        K: std::borrow::Borrow<Q>,
+    {
+        // Use a loop to avoid async tail recursion on leader dropped
+        let mut fut_opt = Some(fut);
+        loop {
+            let handler = if let Some(state_ref) = self.map.get(key) {
+                let state = state_ref.borrow().clone();
+                match state {
+                    State::Starting => ChannelHandler::Receiver(state_ref.clone()),
+                    State::LeaderDropped => {
+                        drop(state_ref);
+                        // switch into leader if leader dropped
+                        let (tx, rx) = watch::channel(State::Starting);
+                        self.map.insert(key.to_owned(), rx);
+                        ChannelHandler::Sender(tx)
+                    }
+                    State::Success(val) => return val,
+                    State::LeaderFailed => unreachable!(),
+                }
+            } else {
+                let (tx, rx) = watch::channel(State::Starting);
+                self.map.insert(key.to_owned(), rx);
+                ChannelHandler::Sender(tx)
+            };
+
+            match handler {
+                ChannelHandler::Sender(tx) => {
+                    let fut = Leader::new(
+                        fut_opt
+                            .take()
+                            .expect("future should be available when becoming leader"),
+                        tx,
+                    );
+                    let result = fut.await;
+                    let _ = self.map.remove(key);
+                    return result;
+                }
+                ChannelHandler::Receiver(mut rx) => {
+                    let mut state = rx.borrow_and_update().clone();
+                    if matches!(state, State::Starting) {
+                        let _changed = rx.changed().await;
+                        state = rx.borrow().clone();
+                    }
+                    match state {
+                        State::LeaderDropped => {
+                            let _ = self.map.remove(key);
+                            // the leader dropped, so we retry the loop, potentially becoming leader
+                            continue;
+                        }
+                        State::Success(val) => return val,
+                        _ => unreachable!(), // unreachable
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Making keys more flexible
- Remove async recursion
- Migrate to `dashmap`
- Reuse common struct, change the return type of `work`