### PR TITLE
refactor: back Mutex and std::HashMap in Group and UnaryGroup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "async_singleflight"
 version = "0.6.0"
 dependencies = [
- "dashmap",
  "futures",
  "pin-project",
  "thiserror",
@@ -66,26 +65,6 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
 
 [[package]]
 name = "futures"
@@ -183,12 +162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +222,6 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "async_singleflight"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_singleflight"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Pure White <wudi@purewhite.io>"]
 edition = "2021"
 description = "Async singleflight."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["asynchronous", "concurrency", "caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dashmap = "6"
 thiserror = "2"
 pin-project = "1"
 tokio = { version = "1", features = [ "sync" ] }

--- a/src/group.rs
+++ b/src/group.rs
@@ -2,30 +2,20 @@ use super::*;
 
 /// Group represents a class of work and creates a space in which units of work
 /// can be executed with duplicate suppression.
-pub struct Group<T, E, K = String>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
-    map: DashMap<K, watch::Receiver<State<T>>>,
+pub struct Group<K, T, E> {
+    map: Mutex<HashMap<K, watch::Receiver<State<T>>>>,
     _marker: PhantomData<fn(E)>,
 }
 
-impl<T, E, K> Debug for Group<T, E, K>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
+pub type DefaultGroup<T, E = ()> = Group<String, T, E>;
+
+impl<K, T, E> Debug for Group<K, T, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Group").finish()
     }
 }
 
-impl<T, E, K> Default for Group<T, E, K>
-where
-    T: Clone,
-    K: Hash + Eq,
-{
+impl<K, T, E> Default for Group<K, T, E> {
     fn default() -> Self {
         Self::new()
     }
@@ -42,76 +32,60 @@ pub enum GroupWorkError<E> {
 }
 
 impl<E> GroupWorkError<E> {
-    pub fn unwrap_err(self) -> E {
+    #[inline(always)]
+    pub fn err(self) -> Option<E> {
         match self {
-            GroupWorkError::Error(err) => err,
-            _ => panic!("called `unwrap_err` on a non-error variant"),
-        }
-    }
-
-    pub fn as_ref(&self) -> GroupWorkError<&E> {
-        match self {
-            GroupWorkError::Error(err) => GroupWorkError::Error(err),
-            GroupWorkError::LeaderFailed => GroupWorkError::LeaderFailed,
-            GroupWorkError::LeaderDropped => GroupWorkError::LeaderDropped,
-        }
-    }
-
-    pub fn into_inner(self) -> E {
-        match self {
-            GroupWorkError::Error(err) => err,
-            _ => panic!("called `into_inner` on a non-error variant"),
-        }
-    }
-}
-
-impl<E> From<GroupWorkError<E>> for Option<E> {
-    fn from(err: GroupWorkError<E>) -> Self {
-        match err {
             GroupWorkError::Error(e) => Some(e),
             _ => None,
         }
     }
 }
 
-impl<T, E, K> Group<T, E, K>
+impl<K, T, E> Group<K, T, E> {
+    /// Create a new Group to do work with.
+    #[must_use]
+    pub fn new() -> Group<K, T, E> {
+        Self {
+            map: Mutex::new(HashMap::new()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<K, T, E> Group<K, T, E>
 where
     T: Clone,
     K: Hash + Eq,
 {
-    /// Create a new Group to do work with.
-    #[must_use]
-    pub fn new() -> Group<T, E, K> {
-        Self {
-            map: DashMap::new(),
-            _marker: PhantomData,
-        }
-    }
-
     async fn work_inner<Q, F>(&self, key: &Q, fut: &mut Option<F>) -> Result<T, GroupWorkError<E>>
     where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        Q: Hash + Eq + ?Sized + Send + Sync + ToOwned<Owned = K>,
         F: Future<Output = Result<T, E>> + Send,
         K: std::borrow::Borrow<Q>,
     {
-        let handler = if let Some(state_ref) = self.map.get(key) {
-            let state = state_ref.borrow().clone();
-            match state {
-                State::Starting => ChannelHandler::Receiver(state_ref.clone()),
-                State::LeaderDropped => {
-                    drop(state_ref);
-                    // switch into leader if leader dropped
+        let handler = {
+            let mut locked_map = self.map.lock().await;
+            match locked_map.get_mut(key) {
+                Some(state_ref) => {
+                    let state = state_ref.borrow().clone();
+                    match state {
+                        State::Starting => ChannelHandler::Receiver(state_ref.clone()),
+                        State::LeaderDropped => {
+                            // switch into leader if leader dropped
+                            let (tx, rx) = watch::channel(State::Starting);
+                            *state_ref = rx;
+                            ChannelHandler::Sender(tx)
+                        }
+                        State::Success(val) => return Ok(val),
+                        State::LeaderFailed => return Err(GroupWorkError::LeaderFailed),
+                    }
+                }
+                None => {
                     let (tx, rx) = watch::channel(State::Starting);
-                    self.map.insert(key.to_owned(), rx);
+                    locked_map.insert(key.to_owned(), rx);
                     ChannelHandler::Sender(tx)
                 }
-                State::Success(val) => return Ok(val),
-                State::LeaderFailed => return Err(GroupWorkError::LeaderFailed),
             }
-        } else {
-            let (tx, rx) = watch::channel(State::Starting);
-            self.map.insert(key.to_owned(), rx);
-            ChannelHandler::Sender(tx)
         };
 
         match handler {
@@ -122,7 +96,7 @@ where
                     tx,
                 );
                 let result = leader.await;
-                let _ = self.map.remove(key);
+                self.map.lock().await.remove(key);
                 match result {
                     Ok(val) => Ok(val),
                     Err(err) => Err(GroupWorkError::Error(err)),
@@ -137,7 +111,7 @@ where
                 match state {
                     State::Starting => unreachable!(), // unreachable
                     State::LeaderDropped => {
-                        let _ = self.map.remove(key);
+                        self.map.lock().await.remove(key);
                         // the leader dropped
                         Err(GroupWorkError::LeaderDropped)
                     }
@@ -153,10 +127,11 @@ where
     ///
     /// - If a duplicate call comes in, that caller will wait until the original
     ///   call completes and return the same value.
-    /// - Only owner call returns error if exists.
+    /// - If the leader returns an error, owner call returns error,
+    ///   others will return `Err(None)`.
     pub async fn work<Q, F>(&self, key: &Q, fut: F) -> Result<T, Option<E>>
     where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        Q: Hash + Eq + ?Sized + Send + Sync + ToOwned<Owned = K>,
         F: Future<Output = Result<T, E>> + Send,
         K: std::borrow::Borrow<Q>,
     {
@@ -181,11 +156,12 @@ where
     ///
     /// - If a duplicate call comes in, that caller will wait until the original
     ///   call completes and return the same value.
-    /// - Only owner call returns error if exists.
-    /// - If the leader drops, the call will return `None`.
+    /// - If the leader returns an error, owner call returns error,
+    ///   others will return `Err(GroupWorkError::LeaderFailed)`.
+    /// - If the leader drops, the call will return `Err(GroupWorkError::LeaderDropped)`.
     pub async fn work_no_retry<Q, F>(&self, key: &Q, fut: F) -> Result<T, GroupWorkError<E>>
     where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = K> + Send + Sync,
+        Q: Hash + Eq + ?Sized + Send + Sync + ToOwned<Owned = K>,
         F: Future<Output = Result<T, E>> + Send,
         K: std::borrow::Borrow<Q>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 
 use std::fmt::{self, Debug};
 use std::future::Future;
+use std::hash::BuildHasher;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -51,8 +52,8 @@ pub use unary::*;
 use pin_project::{pin_project, pinned_drop};
 use std::collections::HashMap;
 use std::hash::Hash;
-use tokio::sync::watch;
-use tokio::sync::Mutex;
+use std::hash::RandomState;
+use tokio::sync::{watch, Mutex};
 
 #[derive(Clone)]
 enum State<T> {
@@ -234,7 +235,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_leader() {
-        let group = Arc::new(Group::new());
+        let group = Arc::new(DefaultGroup::new());
 
         // Signal when the leader's inner future gets polled (implies map entry inserted).
         let (ready_tx, ready_rx) = oneshot::channel::<()>();


### PR DESCRIPTION
- dashmap may got multiple read lock so there are maybe more than one thread think they shoule be the leader
- `hashbrown::hash_map::EntryRef` only support `&'b Q: Into<K>`, where we cannot even use `&42` to got `42` for insertion
- use `tokio::sync::Mutex` to avoid thread blocking and allow other asynchronous tasks to execute